### PR TITLE
Do not pass the event name to the listener function

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@
 
         var collection = this.collection;
 
-        listener.once = once || false;
+        listener.once = once || false;
 
         if (collection[event] === undefined) {
             collection[event] = [];
@@ -205,7 +205,7 @@
      * me.emit("ready", "param1", "param2");
      */
     Jvent.prototype.emit = function () {
-        var args = arguments,
+        var args = Array.prototype.slice.call( arguments, 0 ), //converted to array
             event = args[0],
             listeners,
             i,
@@ -227,9 +227,11 @@
             listeners = this.collection[event.type];
             i = 0;
             len = listeners.length;
+            
+            var listenerArgs = args.splice(1); //remove event name
 
             for (i; i < len; i += 1) {
-                listeners[i].apply(this, arguments);
+                listeners[i].apply(this, listenerArgs);
 
                 if (listeners[i].once) {
                     this.off(event.type, listeners[i]);

--- a/test/spec/jventSpec.js
+++ b/test/spec/jventSpec.js
@@ -237,7 +237,7 @@ describe('Jvent', function () {
 		it('Should emit call all listeners with parameters', function () {
 			emitter.emit('something', 'param1');
 
-			expect(listener).toHaveBeenCalledWith('something', 'param1');
+			expect(listener).toHaveBeenCalledWith('param1');
 		});
 	});
 });


### PR DESCRIPTION
I have changed the emitter class to not pass the event name as an argument to the function. It was passing it as the first arg.

It is what node.js EventEmitter does

http://nodejs.org/api/events.html#events_emitter_on_event_listener
